### PR TITLE
Hamishgibbs detect missing files

### DIFF
--- a/colocation_datsets.csv
+++ b/colocation_datsets.csv
@@ -1,2 +1,2 @@
 ﻿country,id,year,month,day
-Britain,2.29181E+14,2020,2,11
+Britain,229180671540661.00,2020,2,11

--- a/pull_colocation.py
+++ b/pull_colocation.py
@@ -73,9 +73,9 @@ def main(_args):
         
         urls = get_urls(base_url, data_dates)
         
-        download_data(urls, keys)
+        start_time = download_data(urls, keys)
     
-        move_most_recent_files(_args[len(_args) - 1] + "/" + data_target.loc[i, 'country'] + '_colocation', urls)
+        move_most_recent_files(_args[len(_args) - 1] + "/" + data_target.loc[i, 'country'] + '_colocation', urls, start_time)
     
     print('Success.')
 

--- a/pull_mobility.py
+++ b/pull_mobility.py
@@ -66,10 +66,9 @@ def main(_args):
             
         urls = get_urls(base_url, data_dates)
         
-        download_data(urls, keys)
-        
+        start_time = download_data(urls, keys)
     
-        move_most_recent_files(country_output, urls)
+        move_most_recent_files(country_output, urls, start_time)
     
     print('Success.')
 

--- a/pull_population.py
+++ b/pull_population.py
@@ -67,10 +67,9 @@ def main(_args):
             
         urls = get_urls(base_url, data_dates)
         
-        download_data(urls, keys)
-        
+        start_time = download_data(urls, keys)
     
-        move_most_recent_files(country_output, urls)
+        move_most_recent_files(country_output, urls, start_time)
     
     print('Success.')
 

--- a/utils.py
+++ b/utils.py
@@ -61,11 +61,13 @@ def download_data(urls: list, keys: list):
 
     Returns
     -------
-    None.
+    Start time of downloads.
 
     '''
     
     driver = webdriver.Chrome(executable_path='/Applications/chromedriver')
+    
+    download_start = time.time()
     
     driver.get(urls[0])
     
@@ -85,6 +87,8 @@ def download_data(urls: list, keys: list):
     bar.finish()
     
     driver.quit()
+    
+    return(download_start)
 
 def rename_and_move(old_fn: str, old_dir: str, new_fn: str, new_dir: str):
     '''
@@ -132,7 +136,7 @@ def get_new_file_name(file: str):
     
     return(country + '_' + date + '.csv')
     
-def move_most_recent_files(outdir: str, urls: list):
+def move_most_recent_files(outdir: str, urls: list, download_start: float):
     '''
     get the most recent files form the download directory, rename them, and put them in the destination directory
 
@@ -157,13 +161,15 @@ def move_most_recent_files(outdir: str, urls: list):
     for f in glob.glob(get_home_dir() + '/Downloads/*.csv'):
         csv_files[f] = os.path.getctime(f)
         
-    sorted_files = [f[0] for f in sorted(csv_files.items(), key=operator.itemgetter(1), reverse=True)[:len(urls)]]
-    
-    new_fns = [get_new_file_name(file) for file in sorted_files]
-    
-    for i, sorted_file in enumerate(sorted_files):
+    downloaded_files = dict((k, v) for k, v in csv_files.items() if v >= download_start) 
         
-        rename_and_move(sorted_file.split('/')[-1], get_home_dir() + '/Downloads', new_fns[i], outdir)
+    #sorted_files = [f[0] for f in sorted(csv_files.items(), key=operator.itemgetter(1), reverse=True)[:len(urls)]]
+    
+    new_fns = [get_new_file_name(file) for file in downloaded_files]
+    
+    for i, f in enumerate(downloaded_files):
+        
+        rename_and_move(f.split('/')[-1], get_home_dir() + '/Downloads', new_fns[i], outdir)
 #%%
 def get_update_date(outdir: str):
     '''

--- a/utils.py
+++ b/utils.py
@@ -189,9 +189,22 @@ def get_update_date(outdir: str):
     latest_addition = []
     
     for i, f in enumerate(glob.glob(outdir + '/*.csv')):
-        latest_addition.append(int(os.path.getmtime(f)))
+        
+        f_date_parse = f.split('/')[-1].split('.')[0].split('_')
+        
+        year = int(f_date_parse[1])
+        month = int(f_date_parse[2])
+        day = int(f_date_parse[3])
+        
+        try:
+            hour = int(f_date_parse[4].strip('0'))
+        except:
+            hour = 0
+        
+        
+        latest_addition.append(datetime(year, month, day, hour))
     
-    return(datetime.fromtimestamp(max(latest_addition)))
+    return(max(latest_addition))
     
     
     


### PR DESCRIPTION
Detect when files are not downloaded and only rename and move those files that have been successfully downloaded. 

Also, determine the most recently downloaded dataset by parsing dates from filenames, rather than from file times. I believe this is more stable as file ctimes could change. This option, on the other hand, relies on a standard naming convention defined by the download routine. If file names are changed this approach will also fail.  

Fixes #9 and #4 