### PR TITLE
sort download dates

### DIFF
--- a/pull_fb/pull_fb.py
+++ b/pull_fb/pull_fb.py
@@ -126,6 +126,8 @@ def pull_fb(dataset_name,
     # Only download dates that have not already been downloaded
     download_dates = list(set(data_dates).difference(set(existing_dates)))
 
+    download_dates.sort()
+
     # Get url of each of dataset
     download_urls = url.format_urls(dataset_name,
                                     config["dataset_id"],


### PR DESCRIPTION
This will make datasets be downloaded in chronological order (rather than what appears to be a random order as a result of the set difference operation).